### PR TITLE
Fix contributing instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,12 @@ $ npm run build
 
 ## Contributing
 
-Work on a branch, install dev-dependencies, respect coding style & run tests before submitting a bug fix or a feature.
+Work on a branch, install dev-dependencies and respect the coding style before submitting a bug fix or a feature.
 
 ```console
 $ git clone https://github.com/magsout/starter-kit.git
 $ git checkout -b patch-1
 $ npm install
-$ npm test
 ```
 
 ## [License](LICENSE)


### PR DESCRIPTION
There is no `test` script, so telling beginners that they should run `npm test` before contributing might confuse them since they can't.
